### PR TITLE
Update README.md with dependencies for venv and mysqlclient installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Dimensional data modeling
 ## Prerequisites
+### Option 1: Setup with Anaconda (Conda)
 Configure a modelingcourse environment with Anaconda, an open source package management system.
 
 1. Install miniconda on your machine following the instructions:
@@ -34,3 +35,37 @@ conda clean -tp
 6. To activate the environment:
 <br/>OS X and Linux: ```$ source activate modelingcourse```
 <br/>Windows:```$ source activate modelingcourse```
+
+### Option 2: Setup with Python and venv (without Conda)
+
+Alternatively, you can set up the environment using `python3 -m venv` and `pip` to install the dependencies. Follow the steps below:
+
+1. Make sure you have Python 3.10 installed on your machine.
+
+2. **For Linux users**, ensure that the `venv` module is installed, `pkg-config` and MySQL development libraries. Run the following command:
+<br/>```sudo apt update```
+<br/>```sudo apt install python3-venv -y```
+<br/>```sudo apt install pkg-config libmysqlclient-dev build-essential -y```
+
+3. Clone the GitHub repository:
+
+```bash
+git clone https://github.com/team-data-science/dimensional-data-modeling.git
+cd dimensional-data-modeling/assets_scripts
+```
+
+4. Create a new virtual environment using `venv`:
+
+```
+python3 -m venv modelingenv
+```
+
+5. To activate the environment:
+<br/>OS X and Linux: ```source modelingenv/bin/activate```
+<br/>Windows:```modelingenv\Scripts\activate```
+
+6. Install the dependencies listed in `requirements.txt` using `pip`. The `requirements.txt` file is located in the `assets_scripts` directory:
+
+```
+pip install -r assets_scripts/requirements.txt
+```

--- a/assets_scripts/requirements.txt
+++ b/assets_scripts/requirements.txt
@@ -1,0 +1,9 @@
+duckdb==0.9.1
+SQLAlchemy==1.4.44
+mysqlclient==2.2.0
+pygrametl==2.8
+mysql-connector-python==8.1.0
+pandas==2.0.3
+pymysql==1.1.0
+jupyter==1.0.0
+openpyxl==3.1.2


### PR DESCRIPTION
I've added an option to install the prerequisites using venv instead of conda